### PR TITLE
chore: update compatibilityDate to 2026-06-30

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
     '/': { prerender: true }
   },
 
-  compatibilityDate: '2025-01-15',
+  compatibilityDate: '2026-06-30',
 
   eslint: {
     config: {


### PR DESCRIPTION
Updates the Nuxt `compatibilityDate` to today's date (2026-06-30).